### PR TITLE
feat: add two actions to set picture from IdP

### DIFF
--- a/examples/add_picture_claim_from_idp_metadata.js
+++ b/examples/add_picture_claim_from_idp_metadata.js
@@ -1,0 +1,26 @@
+/**
+ * Set picture claim from IdP picture metadata
+ *
+ * Flow: Complement token, Trigger: Pre Userinfo creation, Pre access token creation
+ *
+ * @param ctx
+ * @param api
+ */
+function add_picture_claim_from_idp_metadata(ctx, api) {
+  // return if picture already set
+  if (ctx.v1.claims && ctx.v1.claims.picture) {
+      return;
+  }
+
+  const metadata = ctx.v1.user.getMetadata();
+
+  for (let i in metadata.metadata) {
+      if (metadata.metadata[i].key == "idpPicture") {
+          let picture = metadata.metadata[i].value
+          if (picture) {
+              api.v1.claims.setClaim('picture', picture);
+          }
+          break
+      }
+  }
+}

--- a/examples/set_idp_picture_metadata.js
+++ b/examples/set_idp_picture_metadata.js
@@ -1,0 +1,20 @@
+/**
+ * Set IdP picture as metadata
+ *
+ * Flow: External Authentication, Trigger: Post authentication
+ *
+ * @param ctx
+ * @param api
+ */
+function set_idp_picture_metadata(ctx, api) {
+  // return if api undefined
+  if (api === undefined) {
+      return;
+  }
+
+  const picture = ctx.getClaim('picture');
+
+  if (picture !== null) {
+      api.v1.user.appendMetadata('idpPicture', picture);
+  }
+}


### PR DESCRIPTION
IdP picture value is stored in metadata, then in token claim only if not already set.