### PR TITLE
Added line to fix account linking with external IdPs

### DIFF
--- a/actions-v2-cloudflare-workers/scripts/idp-mapping/idp-mapping.js
+++ b/actions-v2-cloudflare-workers/scripts/idp-mapping/idp-mapping.js
@@ -115,7 +115,10 @@ function mapIdpAttributes(receivedObject, IDP_ID_1, IDP_ID_2) {
       nickName: attrs.FullName?.[0],
       displayName: attrs.FullName?.[0],
     };
+    // Required for Login V2 user creation flows (first login)
     receivedObject.addHumanUser.idpLinks[0].userName = attrs.Email?.[0];
+    // Required for Login V2 account linking to work
+    receivedObject.idpInformation.userName = attrs.Email?.[0];
     console.log("[Mapping] Attributes mapped for SAML provider");
   }
 


### PR DESCRIPTION
Added line to fix account linking with external IdPs in idp-mapping action code.
See issue [#11421](https://github.com/zitadel/zitadel/issues/11421#issuecomment-4007666641) for reference.